### PR TITLE
fix: upgrade `actions/upload-artifact` to v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,11 +3,11 @@ name: cypress tests
 on:
   push:
     branches-ignore:
-      - 'release-please-**'
+      - "release-please-**"
 
 jobs:
   cypress-run:
-    concurrency: cypress-${{ github.head_ref || github.ref }}
+    concurrency: cypress-${{ github.head_ref || github.ref }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -16,7 +16,7 @@ jobs:
       - name: set up node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: "16"
 
       - name: Yarn Install and Cache
         uses: graasp/graasp-deploy/.github/actions/yarn-install-and-cache@v1
@@ -41,15 +41,7 @@ jobs:
           # point to new cypress@10 config file
           config-file: cypress.config.ts
 
-      # - name: Run Component tests 🧪
-      #   uses: cypress-io/github-action@v5
-      #   with:
-      #     # we have already installed everything
-      #     install: false
-      #     # to run component tests we need to use "component: true"
-      #     component: true
-
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
In this PR I update the `actions/upload-artifact` workflow used in the cypress tests CI workflow to v4.

The currently used version of this workflow (v3) will be closing on January 30th 2025 (end of this month). It has been deprecated since mid of last year.

### Context

The impacted workflow is responsible for running automated interface tests using Cypress.
The action that needs to be upgraded is used to upload screenshots of failing tests.

It looks like Cypress is not used to test this application so this PR can either be merged to upgrade the action even if the workflow is not really used,
or the cypress workflow can be removed entirely. 

Please let me know if you would like me to change something in this PR.

